### PR TITLE
Uf 4499 only send solution memo for solved status requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>se.sundsvall.dept44</groupId>
 		<artifactId>dept44-service-parent</artifactId>
-		<version>1.28</version>
+		<version>1.30</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>se.sundsvall</groupId>

--- a/src/integration-test/resources/UpdateCaseSupportFlow/__files/test004_resolveCaseWithSerialNumber/mappings/pob_update_case_secondcall.json
+++ b/src/integration-test/resources/UpdateCaseSupportFlow/__files/test004_resolveCaseWithSerialNumber/mappings/pob_update_case_secondcall.json
@@ -1,6 +1,6 @@
 {
 	"scenarioName": "resolve-case",
-	"requiredScenarioState": "CaseSolved",	
+	"requiredScenarioState": "CaseSolved",
 	"name": "pob-update-case-to-closed",
 	"request": {
 		"headers": {
@@ -22,7 +22,7 @@
 						"Id": "910277",
 						"Virtual.Shop_CI_Name": "Dell Latitude 5320"
 					},
-                    "Memo": null
+					"Memo": null
 				}
 			}
 		]

--- a/src/integration-test/resources/UpdateCaseSupportFlow/__files/test004_resolveCaseWithSerialNumber/mappings/pob_update_case_secondcall.json
+++ b/src/integration-test/resources/UpdateCaseSupportFlow/__files/test004_resolveCaseWithSerialNumber/mappings/pob_update_case_secondcall.json
@@ -22,15 +22,7 @@
 						"Id": "910277",
 						"Virtual.Shop_CI_Name": "Dell Latitude 5320"
 					},
-					"Memo": {
-						"Solution": {
-							"Extension": ".html",
-							"IsValidForWeb": false,
-							"Style": "2",
-							"Memo": "Enheten utbytt",
-							"HandleSeparators": true
-						}
-					}
+                    "Memo": null
 				}
 			}
 		]

--- a/src/integration-test/resources/UpdateCaseSupportFlow/__files/test005_resolveCaseWithoutSerialNumber/mappings/pob_update_case_secondcall.json
+++ b/src/integration-test/resources/UpdateCaseSupportFlow/__files/test005_resolveCaseWithoutSerialNumber/mappings/pob_update_case_secondcall.json
@@ -20,15 +20,7 @@
 						"CaseStatus": "Closed",
 						"Id": "910277"
 					},
-					"Memo": {
-						"Solution": {
-							"Extension": ".html",
-							"IsValidForWeb": false,
-							"Style": "2",
-							"Memo": "Mjukvara ominstallerad",
-							"HandleSeparators": true
-						}
-					}
+                    "Memo": null
 				}
 			}
 		]

--- a/src/integration-test/resources/UpdateCaseSupportFlow/__files/test005_resolveCaseWithoutSerialNumber/mappings/pob_update_case_secondcall.json
+++ b/src/integration-test/resources/UpdateCaseSupportFlow/__files/test005_resolveCaseWithoutSerialNumber/mappings/pob_update_case_secondcall.json
@@ -1,6 +1,6 @@
 {
 	"scenarioName": "resolve-case",
-	"requiredScenarioState": "CaseSolved",	
+	"requiredScenarioState": "CaseSolved",
 	"name": "pob-update-case-to-closed",
 	"request": {
 		"headers": {
@@ -20,7 +20,7 @@
 						"CaseStatus": "Closed",
 						"Id": "910277"
 					},
-                    "Memo": null
+					"Memo": null
 				}
 			}
 		]

--- a/src/main/java/se/sundsvall/supportcenter/api/AssetResource.java
+++ b/src/main/java/se/sundsvall/supportcenter/api/AssetResource.java
@@ -1,15 +1,17 @@
 package se.sundsvall.supportcenter.api;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.headers.Header;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.HttpHeaders.LOCATION;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
+import static org.springframework.http.ResponseEntity.created;
+import static org.springframework.http.ResponseEntity.noContent;
+import static org.springframework.http.ResponseEntity.ok;
+
+import java.util.List;
+
+import javax.validation.Valid;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -25,30 +27,26 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.zalando.problem.Problem;
 import org.zalando.problem.violations.ConstraintViolationProblem;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import se.sundsvall.supportcenter.api.model.Asset;
 import se.sundsvall.supportcenter.api.model.CreateAssetRequest;
 import se.sundsvall.supportcenter.api.model.CreateAssetResponse;
 import se.sundsvall.supportcenter.api.model.UpdateAssetRequest;
 import se.sundsvall.supportcenter.service.AssetService;
 
-import javax.validation.Valid;
-import java.util.List;
-
-import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
-import static org.springframework.http.HttpHeaders.LOCATION;
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
-import static org.springframework.http.ResponseEntity.created;
-import static org.springframework.http.ResponseEntity.noContent;
-import static org.springframework.http.ResponseEntity.ok;
-
 @RestController
 @Validated
 @RequestMapping("/assets")
 @Tag(name = "Asset", description = "Asset operations")
 public class AssetResource {
-
-	private static final Logger LOG = LoggerFactory.getLogger(AssetResource.class);
 
 	@Autowired
 	private AssetService assetService;
@@ -68,7 +66,6 @@ public class AssetResource {
 		@RequestBody @Valid CreateAssetRequest body) {
 
 		String pobId = assetService.createAsset(pobKey, body);
-
 		return created(uriComponentsBuilder.path("/assets/{serialNumber}").buildAndExpand(body.getSerialNumber()).toUri())
 			.header(CONTENT_TYPE, APPLICATION_JSON_VALUE)
 			.body(CreateAssetResponse.create().withId(pobId));
@@ -84,7 +81,6 @@ public class AssetResource {
 	public ResponseEntity<List<Asset>> getAssets(
 		@Parameter(name = "pobKey", description = "The POB API-key", required = true) @RequestHeader("pobKey") String pobKey,
 		@Parameter(name = "serialNumber", description = "The serial number of the asset", example = "4VV3RN2") @RequestParam(name = "serialNumber") String serialNumber) {
-		LOG.debug("Received getAssets request: serialNumber='{}'", serialNumber);
 
 		return ok(assetService.getConfigurationItemsBySerialNumber(pobKey, serialNumber));
 	}
@@ -101,10 +97,8 @@ public class AssetResource {
 		@Parameter(name = "pobKey", description = "The POB API-key", required = true) @RequestHeader("pobKey") String pobKey,
 		@Parameter(name = "serialNumber", description = "The serial number of the asset", required = true, example = "4VV3RN2") @PathVariable(name = "serialNumber") String serialNumber,
 		@RequestBody @Valid UpdateAssetRequest body) {
-		LOG.debug("Received updateAsset request: serialNumber='{}', body='{}'", serialNumber, body);
 
 		assetService.updateConfigurationItem(pobKey, serialNumber, body);
-
 		return noContent().build();
 	}
 }

--- a/src/main/java/se/sundsvall/supportcenter/api/CaseResource.java
+++ b/src/main/java/se/sundsvall/supportcenter/api/CaseResource.java
@@ -4,9 +4,9 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.ALL_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
+import static org.springframework.http.ResponseEntity.created;
 import static org.springframework.http.ResponseEntity.noContent;
 import static org.springframework.http.ResponseEntity.ok;
-import static org.springframework.http.ResponseEntity.created;
 
 import javax.validation.Valid;
 
@@ -58,7 +58,6 @@ public class CaseResource {
 										   @RequestBody @Valid CreateCaseRequest body) {
 
 		var caseId = caseService.createCase(pobKey, body);
-
 		return created(uriComponentsBuilder.path("/cases/{caseId}").buildAndExpand(caseId).toUri())
 				.header(CONTENT_TYPE, ALL_VALUE)
 				.build();
@@ -78,7 +77,6 @@ public class CaseResource {
 		@RequestBody @Valid UpdateCaseRequest body) {
 
 		caseService.updateCase(pobKey, caseId, body);
-
 		return noContent().build();
 	}
 

--- a/src/main/java/se/sundsvall/supportcenter/api/ConfigurationResource.java
+++ b/src/main/java/se/sundsvall/supportcenter/api/ConfigurationResource.java
@@ -6,8 +6,6 @@ import static org.springframework.http.ResponseEntity.ok;
 
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -33,8 +31,6 @@ import se.sundsvall.supportcenter.service.ConfigurationService;
 @Tag(name = "Configuration", description = "Configuration operations")
 public class ConfigurationResource {
 
-	private static final Logger LOG = LoggerFactory.getLogger(ConfigurationResource.class);
-
 	@Autowired
 	private ConfigurationService configurationService;
 
@@ -47,8 +43,6 @@ public class ConfigurationResource {
 	@ApiResponse(responseCode = "502", description = "Bad Gateway", content = @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(implementation = Problem.class)))
 	public ResponseEntity<List<String>> getCaseCategoryList(
 		@Parameter(name = "pobKey", description = "The POB API-key", required = true) @RequestHeader("pobKey") String pobKey) {
-		LOG.debug("Received getCaseCategoryList request");
-
 		return ok(configurationService.getCaseCategoryList(pobKey));
 	}
 
@@ -61,8 +55,6 @@ public class ConfigurationResource {
 	@ApiResponse(responseCode = "502", description = "Bad Gateway", content = @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(implementation = Problem.class)))
 	public ResponseEntity<List<String>> getClosureCodeList(
 		@Parameter(name = "pobKey", description = "The POB API-key", required = true) @RequestHeader("pobKey") String pobKey) {
-		LOG.debug("Received getClosureCodeList request");
-
 		return ok(configurationService.getClosureCodeList(pobKey));
 	}
 }

--- a/src/main/java/se/sundsvall/supportcenter/integration/pob/POBClient.java
+++ b/src/main/java/se/sundsvall/supportcenter/integration/pob/POBClient.java
@@ -1,9 +1,11 @@
 package se.sundsvall.supportcenter.integration.pob;
 
-import generated.client.pob.PobPayload;
-import generated.client.pob.PobPayloadWithTriggerResults;
-import generated.client.pob.SuspensionInfo;
-import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static se.sundsvall.supportcenter.integration.pob.configuration.POBConfiguration.CLIENT_ID;
+
+import java.util.List;
+
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -13,16 +15,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+
+import generated.client.pob.PobPayload;
+import generated.client.pob.PobPayloadWithTriggerResults;
+import generated.client.pob.SuspensionInfo;
 import se.sundsvall.supportcenter.integration.pob.configuration.POBConfiguration;
 
-import java.util.List;
-
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-import static se.sundsvall.supportcenter.integration.pob.configuration.POBConfiguration.CLIENT_ID;
-
 @FeignClient(name = CLIENT_ID, url = "${integration.pob.url}", configuration = POBConfiguration.class)
-@CircuitBreaker(name = CLIENT_ID)
 public interface POBClient {
 
 	/**

--- a/src/main/java/se/sundsvall/supportcenter/integration/pob/POBClient.java
+++ b/src/main/java/se/sundsvall/supportcenter/integration/pob/POBClient.java
@@ -78,7 +78,7 @@ public interface POBClient {
 	 * Returns a list of configuration-items by serialNumber. The returned objects only contains the ID-attribute.
 	 * 
 	 * @param pobKey       the key to use for authorization
-	 * @param serialNumber
+	 * @param serialNumber the serial number to filter the results on
 	 * @return a list of configuration-items
 	 */
 	@GetMapping(path = "configurationitems?Filter=SerialNumber={serialNumber}", produces = APPLICATION_JSON_VALUE)

--- a/src/main/java/se/sundsvall/supportcenter/integration/pob/POBClient.java
+++ b/src/main/java/se/sundsvall/supportcenter/integration/pob/POBClient.java
@@ -27,19 +27,18 @@ public interface POBClient {
 	/**
 	 * Updates an existing case in POB.
 	 * 
-	 * @param pobKey
+	 * @param pobKey  the key to use for authorization
 	 * @param payload the object with the updated case-attributes.
-	 * @return
 	 */
 	@PostMapping(path = "cases", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
 	Void updateCase(@RequestHeader(AUTHORIZATION) String pobKey, @RequestBody PobPayload payload);
 
 	/**
 	 * Creates a case in POB.
-	 *
-	 * @param pobKey
+	 * 
+	 * @param pobKey  the key to use for authorization
 	 * @param payload payload the object with the item to create.
-	 * @return
+	 * @return a list of payload trigger results
 	 */
 	@PutMapping(path = "cases", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
 	List<PobPayloadWithTriggerResults> createCase(@RequestHeader(AUTHORIZATION) String pobKey, @RequestBody PobPayload payload);
@@ -48,7 +47,7 @@ public interface POBClient {
 	/**
 	 * Get an existing case in POB.
 	 * 
-	 * @param pobKey
+	 * @param pobKey the key to use for authorization
 	 * @param caseId the ID of the case.
 	 * @return The case
 	 */
@@ -58,7 +57,7 @@ public interface POBClient {
 	/**
 	 * Returns a list of all available case-categories.
 	 * 
-	 * @param pobKey
+	 * @param pobKey the key to use for authorization
 	 * @return a list of available case-categories (max 10000)
 	 */
 	@Cacheable("case-categories")
@@ -68,7 +67,7 @@ public interface POBClient {
 	/**
 	 * Returns a list of of all available closure-codes.
 	 * 
-	 * @param pobKey
+	 * @param pobKey the key to use for authorization
 	 * @return a list of available closure-codes (max 10000)
 	 */
 	@Cacheable("closure-codes")
@@ -78,7 +77,7 @@ public interface POBClient {
 	/**
 	 * Returns a list of configuration-items by serialNumber. The returned objects only contains the ID-attribute.
 	 * 
-	 * @param pobKey
+	 * @param pobKey       the key to use for authorization
 	 * @param serialNumber
 	 * @return a list of configuration-items
 	 */
@@ -88,8 +87,8 @@ public interface POBClient {
 	/**
 	 * Returns a list containing a item by id.
 	 *
-	 * @param pobKey
-	 * @param id id of an item
+	 * @param pobKey the key to use for authorization
+	 * @param id     id of an item
 	 * @return a list containing an item
 	 */
 	@GetMapping(path = "items?Filter=Id={id}", produces = APPLICATION_JSON_VALUE)
@@ -98,8 +97,8 @@ public interface POBClient {
 	/**
 	 * Returns a list of items by model-name. The returned objects only contains the ID-attribute.
 	 *
-	 * @param pobKey
-	 * @param modelName
+	 * @param pobKey    the key to use for authorization
+	 * @param modelName the item model name to filter response on
 	 * @return a list of configuration-items
 	 */
 	@GetMapping(path = "items?Filter=IdOption={modelName}", produces = APPLICATION_JSON_VALUE)
@@ -108,7 +107,7 @@ public interface POBClient {
 	/**
 	 * Creates an item
 	 *
-	 * @param pobKey
+	 * @param pobKey  the key to use for authorization
 	 * @param payload the object with the updated configuration attributes
 	 * @return list of pob-payloads with triggered results
 	 */
@@ -118,7 +117,7 @@ public interface POBClient {
 	/**
 	 * Updates a configuration-item
 	 *
-	 * @param pobKey
+	 * @param pobKey  the key to use for authorization
 	 * @param payload the object with configuration-items to create
 	 * @return list of pob-payloads with triggered results
 	 */
@@ -128,9 +127,8 @@ public interface POBClient {
 	/**
 	 * Updates a configuration-item
 	 *
-	 * @param pobKey
+	 * @param pobKey  the key to use for authorization
 	 * @param payload the object with the updated configuration attributes
-	 * @return
 	 */
 	@PostMapping(path = "configurationitems", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
 	Void updateConfigurationItem(@RequestHeader(AUTHORIZATION) String pobKey, @RequestBody PobPayload payload);
@@ -138,10 +136,9 @@ public interface POBClient {
 	/**
 	 * Suspend an existing case in POB.
 	 * 
-	 * @param pobKey
-	 * @param caseId the ID of the case
+	 * @param pobKey  the key to use for authorization
+	 * @param caseId  the ID of the case
 	 * @param payload object with suspension information
-	 * @return
 	 */
 	@PostMapping(path = "cases/{caseId}/suspension", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
 	Void suspendCase(@RequestHeader(AUTHORIZATION) String pobKey, @PathVariable("caseId") String caseId, @RequestBody SuspensionInfo payload);
@@ -149,7 +146,7 @@ public interface POBClient {
 	/**
 	 * Get suspension information for a suspended case in POB, if case is not suspended a 404 will be thrown.
 	 * 
-	 * @param pobKey
+	 * @param pobKey the key to use for authorization
 	 * @param caseId the ID of the case
 	 * @return Information about the suspension
 	 */
@@ -159,9 +156,8 @@ public interface POBClient {
 	/**
 	 * Unsuspend a suspended case in POB.
 	 * 
-	 * @param pobKey
+	 * @param pobKey the key to use for authorization
 	 * @param caseId the ID of the case
-	 * @return
 	 */
 	@DeleteMapping(path = "cases/{caseId}/suspension", produces = APPLICATION_JSON_VALUE)
 	Void deleteSuspension(@RequestHeader(AUTHORIZATION) String pobKey, @PathVariable("caseId") String caseId);

--- a/src/main/java/se/sundsvall/supportcenter/service/ConfigurationService.java
+++ b/src/main/java/se/sundsvall/supportcenter/service/ConfigurationService.java
@@ -1,25 +1,22 @@
 package se.sundsvall.supportcenter.service;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
-import org.zalando.problem.Problem;
-import se.sundsvall.supportcenter.integration.pob.POBClient;
-
-import java.util.List;
-
 import static java.lang.String.format;
 import static org.zalando.problem.Status.BAD_REQUEST;
 import static se.sundsvall.supportcenter.service.mapper.ConfigurationMapper.toCaseCategoryList;
 import static se.sundsvall.supportcenter.service.mapper.ConfigurationMapper.toClosureCodeList;
 import static se.sundsvall.supportcenter.service.mapper.ConfigurationMapper.toConfigurationItemList;
 
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.zalando.problem.Problem;
+
+import se.sundsvall.supportcenter.integration.pob.POBClient;
+
 @Service
 public class ConfigurationService {
-
-	private static final Logger LOG = LoggerFactory.getLogger(ConfigurationService.class);
 
 	private static final String VALIDATION_ERROR_TEMPLATE = "%s: '%s' is not a valid value";
 	private static final String SERIAL_NUMBER_ERROR_TEMPLATE = "No ID for serialNumber: '%s' was found in POB-configurationitems";
@@ -28,18 +25,14 @@ public class ConfigurationService {
 	private POBClient pobClient;
 
 	public List<String> getCaseCategoryList(String pobKey) {
-		LOG.debug("Received getCaseCategoryList request");
 		return toCaseCategoryList(pobClient.getCaseCategories(pobKey));
 	}
 
 	public List<String> getClosureCodeList(String pobKey) {
-		LOG.debug("Received getClosureCodeList request");
 		return toClosureCodeList(pobClient.getClosureCodes(pobKey));
 	}
 
 	public void validateCaseCategory(String pobKey, String caseCategory) {
-		LOG.debug("Validating caseCategory: caseCategory='{}'", caseCategory);
-
 		// Ensure that provided caseCategory exists in returned caseCategory list from POB.
 		if (getCaseCategoryList(pobKey).stream().noneMatch(x -> x.equals(caseCategory))) {
 			throw Problem.valueOf(BAD_REQUEST, format(VALIDATION_ERROR_TEMPLATE, "caseCategory", caseCategory));
@@ -47,8 +40,6 @@ public class ConfigurationService {
 	}
 
 	public void validateClosureCode(String pobKey, String closureCode) {
-		LOG.debug("Validating closureCode: closureCode='{}'", closureCode);
-
 		// Ensure that provided closureCode exists in returned closureCode list from POB.
 		if (getClosureCodeList(pobKey).stream().noneMatch(x -> x.equals(closureCode))) {
 			throw Problem.valueOf(BAD_REQUEST, format(VALIDATION_ERROR_TEMPLATE, "closureCode", closureCode));
@@ -56,7 +47,6 @@ public class ConfigurationService {
 	}
 
 	public String getSerialNumberId(String pobKey, String serialNumber) {
-		LOG.debug("Received getSerialNumberId request: serialNumber='{}'", serialNumber);
 		return toConfigurationItemList(pobClient.getConfigurationItemsBySerialNumber(pobKey, serialNumber)).stream()
 			.filter(StringUtils::hasText)
 			.findAny()

--- a/src/main/java/se/sundsvall/supportcenter/service/SupportCenterStatus.java
+++ b/src/main/java/se/sundsvall/supportcenter/service/SupportCenterStatus.java
@@ -18,7 +18,7 @@ public enum SupportCenterStatus {
 	OPEN("Open"),
 	RESOLVED("Resolved");
 	
-	private String value;
+	private final String value;
 	
 	private SupportCenterStatus(String value) {
 		this.value = value;

--- a/src/main/java/se/sundsvall/supportcenter/service/mapper/CreateAssetMapper.java
+++ b/src/main/java/se/sundsvall/supportcenter/service/mapper/CreateAssetMapper.java
@@ -1,17 +1,6 @@
 package se.sundsvall.supportcenter.service.mapper;
 
-import generated.client.pob.PobPayload;
-import generated.client.pob.PobPayloadWithTriggerResults;
-import se.sundsvall.supportcenter.api.model.CreateAssetRequest;
-
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-
+import static java.time.LocalDateTime.now;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_CONFIGURATION_ITEM;
@@ -28,6 +17,18 @@ import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMa
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_SUPPLIER_STATUS;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.TYPE_CONFIGURATION_ITEM;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.TYPE_ITEM;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import generated.client.pob.PobPayload;
+import generated.client.pob.PobPayloadWithTriggerResults;
+import se.sundsvall.supportcenter.api.model.CreateAssetRequest;
 
 public class CreateAssetMapper {
 
@@ -85,7 +86,7 @@ public class CreateAssetMapper {
 		Optional.ofNullable(createAssetRequest.getModelName()).ifPresent(value -> dataMap.put(KEY_ITEM_ID_OPTION, value));
 		Optional.ofNullable(createAssetRequest.getModelDescription()).ifPresent(value -> dataMap.put(KEY_DESCRIPTION, value));
 		Optional.ofNullable(createAssetRequest.getManufacturer()).ifPresent(value -> dataMap.put(KEY_MANUFACTURER, value));
-		dataMap.put(KEY_START_DATE, LocalDateTime.now().format(DATE_TIME_FORMATTER));
+		dataMap.put(KEY_START_DATE, now(ZoneId.systemDefault()).format(DATE_TIME_FORMATTER));
 
 		return dataMap;
 	}

--- a/src/main/java/se/sundsvall/supportcenter/service/mapper/UpdateCaseMapper.java
+++ b/src/main/java/se/sundsvall/supportcenter/service/mapper/UpdateCaseMapper.java
@@ -1,15 +1,5 @@
 package se.sundsvall.supportcenter.service.mapper;
 
-import generated.client.pob.PobMemo;
-import generated.client.pob.PobPayload;
-import se.sundsvall.supportcenter.api.model.Note;
-import se.sundsvall.supportcenter.api.model.UpdateCaseRequest;
-import se.sundsvall.supportcenter.api.model.enums.NoteType;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -31,6 +21,16 @@ import static se.sundsvall.supportcenter.service.mapper.constant.CaseMapperConst
 import static se.sundsvall.supportcenter.service.mapper.constant.CaseMapperConstants.NOTE_DELIVERED;
 import static se.sundsvall.supportcenter.service.mapper.constant.CaseMapperConstants.NOTE_STATUS_PART;
 import static se.sundsvall.supportcenter.service.mapper.constant.CaseMapperConstants.STATUS_DELIVERED;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import generated.client.pob.PobMemo;
+import generated.client.pob.PobPayload;
+import se.sundsvall.supportcenter.api.model.Note;
+import se.sundsvall.supportcenter.api.model.UpdateCaseRequest;
+import se.sundsvall.supportcenter.api.model.enums.NoteType;
 
 public class UpdateCaseMapper {
 
@@ -131,9 +131,10 @@ public class UpdateCaseMapper {
 
 	/**
 	 * Creates a note of note type
-	 * @param noteType
-	 * @param caseStatus
-	 * @return
+	 * 
+	 * @param noteType   the notetype to use
+	 * @param caseStatus the status to be used
+	 * @return a note instance representing sent in parameters
 	 */
 	private static Note createStatusNote(NoteType noteType, String caseStatus) {
 		if (isNull(noteType)) {

--- a/src/main/java/se/sundsvall/supportcenter/service/mapper/constant/CaseMapperConstants.java
+++ b/src/main/java/se/sundsvall/supportcenter/service/mapper/constant/CaseMapperConstants.java
@@ -134,8 +134,10 @@ public class CaseMapperConstants {
 				.withAttributes(Map.of(KEY_CASE_STATUS, STATUS_CLOSED, KEY_EXTERNAL_CASE_ID, ""))));
 	
 		/**
-		 * Method used for the CANCELLED status, as this status need external case id value to be set to null, which Map.of() doesn't allow
-		 * @return
+		 * Method used for the CANCELLED status, as this status need external case id value to be set to null, which Map.of()
+		 * doesn't allow
+		 * 
+		 * @return map with values to be set for the CANCELLED status
 		 */
 		private static Map<String, Object> createAttributesForCancelledStatus() {
 			Map<String, Object> map = from(Map.of(KEY_CASE_STATUS, STATUS_IN_PROCESS, KEY_RESPONSIBLE_GROUP, IT_SUPPORT));
@@ -144,9 +146,10 @@ public class CaseMapperConstants {
 		}
 		
 		/**
-		 * Method used for the ASSIGN_BACK status, as this status need key responsible value to be set to null when programmatically 
-		 * adding key responsible group, which Map.of() doesn't allow
-		 * @return
+		 * Method used for the ASSIGN_BACK status, as this status need key responsible value to be set to null when
+		 * programmatically adding key responsible group, which Map.of() doesn't allow
+		 * 
+		 * @return map with values to be set for the ASSIGN_BACK status
 		 */
 		private static Map<String, Object> createAtributesForAssignBackStatus() {
 			Map<String, Object> map = from(Map.of(KEY_ACTION_NEEDED, true, KEY_ACTION_NEEDED_DESCRIPTION, SEE_INTERNAL_NOTE_FOR_ACTION, KEY_RESPONSIBLE_GROUP, IT_SUPPORT));

--- a/src/main/java/se/sundsvall/supportcenter/service/processor/SolutionNoteProcessor.java
+++ b/src/main/java/se/sundsvall/supportcenter/service/processor/SolutionNoteProcessor.java
@@ -1,0 +1,60 @@
+package se.sundsvall.supportcenter.service.processor;
+
+import static java.util.Objects.nonNull;
+import static java.util.Optional.ofNullable;
+import static se.sundsvall.supportcenter.api.model.enums.NoteType.SOLUTION;
+import static se.sundsvall.supportcenter.service.mapper.constant.CaseMapperConstants.KEY_CASE_STATUS;
+import static se.sundsvall.supportcenter.service.mapper.constant.CaseMapperConstants.STATUS_SOLVED;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import generated.client.pob.PobMemo;
+import generated.client.pob.PobPayload;
+import se.sundsvall.supportcenter.api.model.UpdateCaseRequest;
+/**
+ * Performs customizations on the PobPayload regarding solution memo
+ */
+@Component
+public class SolutionNoteProcessor implements ProcessorInterface {
+	private static final Logger LOG = LoggerFactory.getLogger(SolutionNoteProcessor.class);
+
+	@Override
+	public boolean shouldProcess(UpdateCaseRequest updateCaseRequest) {
+		return nonNull(updateCaseRequest); //This processor should be executed for all requests as long as they are not null
+	}
+
+	/**
+	 * Removes solution memo from the PobPayload before POB update if status does not equal 'Solved' and solution memo is
+	 * present
+	 */
+	@Override
+	public void preProcess(String pobKey, String caseId, UpdateCaseRequest updateCaseRequest, PobPayload pobPayload) {
+		ofNullable(pobPayload)
+			.filter(payload -> nonNull(payload.getData()))
+			.filter(payload -> nonNull(payload.getMemo()))
+			.filter(payload -> payload.getMemo().containsKey(SOLUTION.toValue()))
+			.filter(payload -> !STATUS_SOLVED.equals(payload.getData().get(KEY_CASE_STATUS)))
+			.ifPresent(payload -> {
+				LOG.debug("CaseStatus is '{}' and solution memo is present, removing solution memo from payload", payload.getData().get(KEY_CASE_STATUS));
+				final var filteredMemos = removeSolutionNote(payload);
+				payload.setMemo(filteredMemos.isEmpty() ? null : filteredMemos);
+			});
+	}
+
+	private Map<String, PobMemo> removeSolutionNote(PobPayload pobPayload) {
+		return pobPayload.getMemo().entrySet().stream()
+			.filter(entry -> !SOLUTION.toValue().equals(entry.getKey()))
+			.collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+	}
+
+	@Override
+	public void postProcess(String pobKey, String caseId, UpdateCaseRequest updateCaseRequest, PobPayload pobPayload) {
+		// Serial number processor has nothing to post process
+	}
+}

--- a/src/main/java/se/sundsvall/supportcenter/service/util/CaseUtil.java
+++ b/src/main/java/se/sundsvall/supportcenter/service/util/CaseUtil.java
@@ -20,8 +20,8 @@ public class CaseUtil {
 	/**
 	 * Checks if the key denoted by the provided jsonPath exists and has a value that is not null.
 	 * 
-	 * @param pobPayload
-	 * @param jsonPath
+	 * @param pobPayload the payload to use
+	 * @param jsonPath   the path to verify existance of
 	 * @return true if the key exist and has a non null value.
 	 */
 	public static boolean jsonPathExists(PobPayload pobPayload, String jsonPath) {
@@ -32,8 +32,8 @@ public class CaseUtil {
 	/**
 	 * Extracts the value denoted by the provided jsonPath.
 	 * 
-	 * @param pobPayload
-	 * @param jsonPath
+	 * @param pobPayload         the payload to use
+	 * @param jsonPath           the path extract value from
 	 * @param suppressExceptions whether to suppress exceptions for invalid paths, or not.
 	 * @return the value that corresponds to the provided jsonPath.
 	 */

--- a/src/test/java/se/sundsvall/supportcenter/service/processor/CaseStatusProcessorTest.java
+++ b/src/test/java/se/sundsvall/supportcenter/service/processor/CaseStatusProcessorTest.java
@@ -1,0 +1,92 @@
+package se.sundsvall.supportcenter.service.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static se.sundsvall.supportcenter.service.SupportCenterStatus.ASSIGN_BACK;
+import static se.sundsvall.supportcenter.service.mapper.constant.CaseMapperConstants.KEY_CASE_STATUS;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+import org.junit.jupiter.params.provider.NullSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.stereotype.Component;
+
+import generated.client.pob.PobPayload;
+import se.sundsvall.supportcenter.api.model.UpdateCaseRequest;
+import se.sundsvall.supportcenter.service.SupportCenterStatus;
+
+@ExtendWith(MockitoExtension.class)
+class CaseStatusProcessorTest {
+
+	@Mock
+	private PobPayload pobPayloadMock;
+
+	@Mock
+	private Map<String, Object> mapMock;
+
+	@InjectMocks
+	private CaseStatusProcessor processor;
+
+	@Test
+	void isAssignableFrom() {
+		assertThat(ProcessorInterface.class).isAssignableFrom(processor.getClass());
+	}
+	
+	@Test
+	void hasComponentAnnotation() {
+		assertThat(processor.getClass().getAnnotation(Component.class)).isNotNull();
+	}
+
+	@ParameterizedTest
+	@EnumSource(value = SupportCenterStatus.class, mode = Mode.EXCLUDE, names = "ASSIGN_BACK")
+	@NullSource
+	void shouldNotProcess(SupportCenterStatus status) {
+		final var statusAsString = Optional.ofNullable(status).map(SupportCenterStatus::getValue).orElse(null);
+		assertThat(processor.shouldProcess(UpdateCaseRequest.create().withCaseStatus(statusAsString))).isFalse();
+	}
+
+	@Test
+	void shouldProcess() {
+		assertThat(processor.shouldProcess(UpdateCaseRequest.create().withCaseStatus(ASSIGN_BACK.getValue()))).isTrue();
+	}
+
+	@Test
+	void preProcess() {
+
+		// Parameter values
+		final var pobKey = "pobKey";
+		final var caseId = "12345";
+		final var request = UpdateCaseRequest.create();
+
+		when(pobPayloadMock.getData()).thenReturn(mapMock);
+		
+		// Call
+		processor.preProcess(pobKey, caseId, request, pobPayloadMock);
+
+		// Verification
+		verify(pobPayloadMock, times(2)).getData();
+		verify(mapMock).remove(KEY_CASE_STATUS);
+	}
+	
+	@Test
+	void postProcess() {
+		final var pobKey = "pobKey";
+		final var caseId = "12345";
+		final var request = UpdateCaseRequest.create();
+
+		processor.postProcess(pobKey, caseId, request, pobPayloadMock);
+
+		verifyNoInteractions(pobPayloadMock, mapMock);
+	}
+}

--- a/src/test/java/se/sundsvall/supportcenter/service/processor/SolutionNoteProcessorTest.java
+++ b/src/test/java/se/sundsvall/supportcenter/service/processor/SolutionNoteProcessorTest.java
@@ -211,6 +211,5 @@ class SolutionNoteProcessorTest {
 		processor.postProcess(pobKey, caseId, request, pobPayloadMock);
 
 		verifyNoInteractions(pobPayloadMock, dataMapMock);
-		
 	}
 }

--- a/src/test/java/se/sundsvall/supportcenter/service/processor/SolutionNoteProcessorTest.java
+++ b/src/test/java/se/sundsvall/supportcenter/service/processor/SolutionNoteProcessorTest.java
@@ -1,0 +1,216 @@
+package se.sundsvall.supportcenter.service.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static se.sundsvall.supportcenter.api.model.enums.NoteType.SOLUTION;
+import static se.sundsvall.supportcenter.api.model.enums.NoteType.WORKNOTE;
+import static se.sundsvall.supportcenter.service.mapper.constant.CaseMapperConstants.KEY_CASE_STATUS;
+import static se.sundsvall.supportcenter.service.mapper.constant.CaseMapperConstants.STATUS_CLOSED;
+import static se.sundsvall.supportcenter.service.mapper.constant.CaseMapperConstants.STATUS_SOLVED;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.stereotype.Component;
+
+import generated.client.pob.PobMemo;
+import generated.client.pob.PobPayload;
+import se.sundsvall.supportcenter.api.model.UpdateCaseRequest;
+import se.sundsvall.supportcenter.service.SupportCenterStatus;
+
+@ExtendWith(MockitoExtension.class)
+class SolutionNoteProcessorTest {
+
+	@Mock
+	private PobPayload pobPayloadMock;
+
+	@Mock
+	private Map<String, Object> dataMapMock;
+
+	@InjectMocks
+	private SolutionNoteProcessor processor;
+
+	@Test
+	void isAssignableFrom() {
+		assertThat(ProcessorInterface.class).isAssignableFrom(processor.getClass());
+	}
+	
+	@Test
+	void hasComponentAnnotation() {
+		assertThat(processor.getClass().getAnnotation(Component.class)).isNotNull();
+	}
+
+	@Captor
+	private ArgumentCaptor<Map<String, PobMemo>> argumentCaptor;
+
+	@ParameterizedTest
+	@EnumSource(value = SupportCenterStatus.class)
+	void shouldProcessForAllStatuses(SupportCenterStatus status) {
+		assertThat(processor.shouldProcess(UpdateCaseRequest.create().withCaseStatus(status.getValue()))).isTrue();
+	}
+
+	@Test
+	void shouldNotProcessForNull() {
+		assertThat(processor.shouldProcess(null)).isFalse();
+	}
+
+	@Test
+	void preProcessWhenNoteContainsSolutionAndPayloadStatusIsSolved() {
+
+		// Parameter values
+		final var pobKey = "pobKey";
+		final var caseId = "12345";
+		final var request = UpdateCaseRequest.create();
+		final var memoMap = new HashMap<String, PobMemo>();
+
+		memoMap.put(SOLUTION.toValue(), new PobMemo());
+		memoMap.put(WORKNOTE.toValue(), new PobMemo());
+
+		// Setup mocking
+		when(pobPayloadMock.getData()).thenReturn(dataMapMock);
+		when(dataMapMock.get(KEY_CASE_STATUS)).thenReturn(STATUS_SOLVED);
+		when(pobPayloadMock.getMemo()).thenReturn(memoMap);
+		
+		// Call
+		processor.preProcess(pobKey, caseId, request, pobPayloadMock);
+
+		// Verification
+		verify(pobPayloadMock, times(2)).getData();
+		verify(pobPayloadMock, times(2)).getMemo();
+		verify(dataMapMock).get(KEY_CASE_STATUS);
+		verify(pobPayloadMock, never()).setMemo(any());
+	}
+
+	@Test
+	void preProcessWhenNoteNotEqualsSolutionAndPayloadStatusEqualsSolved() {
+
+		// Parameter values
+		final var pobKey = "pobKey";
+		final var caseId = "12345";
+		final var request = UpdateCaseRequest.create();
+		final var memoMap = new HashMap<String, PobMemo>();
+
+		memoMap.put(WORKNOTE.toValue(), new PobMemo());
+
+		// Setup mocking
+		when(pobPayloadMock.getData()).thenReturn(dataMapMock);
+		when(pobPayloadMock.getMemo()).thenReturn(memoMap);
+
+		// Call
+		processor.preProcess(pobKey, caseId, request, pobPayloadMock);
+
+		// Verification
+		verify(pobPayloadMock).getData();
+		verify(pobPayloadMock, times(2)).getMemo();
+		verify(pobPayloadMock, never()).setMemo(any());
+	}
+
+	@Test
+	void preProcessWhenNoteOnlyContainsSolutionButPayloadStatusNotEqualsSolved() {
+
+		// Parameter values
+		final var pobKey = "pobKey";
+		final var caseId = "12345";
+		final var request = UpdateCaseRequest.create();
+		final var memoMap = new HashMap<String, PobMemo>();
+
+		memoMap.put(SOLUTION.toValue(), new PobMemo());
+
+		// Setup mocking
+		doCallRealMethod().when(pobPayloadMock).setMemo(any());
+		when(pobPayloadMock.getData()).thenReturn(dataMapMock);
+		when(dataMapMock.get(KEY_CASE_STATUS)).thenReturn(STATUS_CLOSED);
+		when(pobPayloadMock.getMemo()).thenReturn(memoMap);
+
+		// Call
+		processor.preProcess(pobKey, caseId, request, pobPayloadMock);
+
+		// Verification
+		verify(pobPayloadMock, times(3)).getData();
+		verify(pobPayloadMock, times(3)).getMemo();
+		verify(dataMapMock, times(2)).get(KEY_CASE_STATUS);
+		verify(pobPayloadMock).setMemo(isNull());
+	}
+
+	@Test
+	void preProcessWhenNoteContainsSolutionButPayloadStatusNotEqualsSolved() {
+
+		// Parameter values
+		final var pobKey = "pobKey";
+		final var caseId = "12345";
+		final var request = UpdateCaseRequest.create();
+		final var memoMap = new HashMap<String, PobMemo>();
+
+		memoMap.put(WORKNOTE.toValue(), new PobMemo());
+		memoMap.put(SOLUTION.toValue(), new PobMemo());
+
+		// Setup mocking
+		doCallRealMethod().when(pobPayloadMock).setMemo(any());
+		when(pobPayloadMock.getData()).thenReturn(dataMapMock);
+		when(dataMapMock.get(KEY_CASE_STATUS)).thenReturn(STATUS_CLOSED);
+		when(pobPayloadMock.getMemo()).thenReturn(memoMap);
+
+		// Call
+		processor.preProcess(pobKey, caseId, request, pobPayloadMock);
+
+		// Verifications and assertions
+		verify(pobPayloadMock, times(3)).getData();
+		verify(pobPayloadMock, times(3)).getMemo();
+		verify(dataMapMock, times(2)).get(KEY_CASE_STATUS);
+		verify(pobPayloadMock).setMemo(argumentCaptor.capture());
+
+		assertThat(argumentCaptor.getValue()).hasSize(1).containsKey(WORKNOTE.toValue());
+	}
+
+	@Test
+	void preProcessWhenNoteNotEqualsSolutionAndPayloadStatusNotEqualsSolved() {
+
+		// Parameter values
+		final var pobKey = "pobKey";
+		final var caseId = "12345";
+		final var request = UpdateCaseRequest.create();
+		final var memoMap = new HashMap<String, PobMemo>();
+
+		memoMap.put(WORKNOTE.toValue(), new PobMemo());
+
+		// Setup mocking
+		when(pobPayloadMock.getData()).thenReturn(dataMapMock);
+		when(pobPayloadMock.getMemo()).thenReturn(memoMap);
+
+		// Call
+		processor.preProcess(pobKey, caseId, request, pobPayloadMock);
+
+		// Verification
+		verify(pobPayloadMock).getData();
+		verify(pobPayloadMock, times(2)).getMemo();
+		verify(pobPayloadMock, never()).setMemo(any());
+	}
+	
+	@Test
+	void postProcess() {
+		final var pobKey = "pobKey";
+		final var caseId = "12345";
+		final var request = UpdateCaseRequest.create();
+
+		processor.postProcess(pobKey, caseId, request, pobPayloadMock);
+
+		verifyNoInteractions(pobPayloadMock, dataMapMock);
+		
+	}
+}

--- a/src/test/java/se/sundsvall/supportcenter/service/processor/SolutionNoteProcessorTest.java
+++ b/src/test/java/se/sundsvall/supportcenter/service/processor/SolutionNoteProcessorTest.java
@@ -37,6 +37,9 @@ import se.sundsvall.supportcenter.service.SupportCenterStatus;
 @ExtendWith(MockitoExtension.class)
 class SolutionNoteProcessorTest {
 
+	@Captor
+	private ArgumentCaptor<Map<String, PobMemo>> argumentCaptor;
+
 	@Mock
 	private PobPayload pobPayloadMock;
 
@@ -55,9 +58,6 @@ class SolutionNoteProcessorTest {
 	void hasComponentAnnotation() {
 		assertThat(processor.getClass().getAnnotation(Component.class)).isNotNull();
 	}
-
-	@Captor
-	private ArgumentCaptor<Map<String, PobMemo>> argumentCaptor;
 
 	@ParameterizedTest
 	@EnumSource(value = SupportCenterStatus.class)


### PR DESCRIPTION
- Removed circuitbreaker annotation on feign client
- Updated Dept44 to version 1.30
- Implemented processing logic to remove solution memo from payload for
all payloads that does not contain 'Solved' as case status
- Added unit test for case status processor