### PR TITLE
Add leaseStart and leaseEnd to asset create/get/update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>se.sundsvall</groupId>
 	<artifactId>api-service-supportcenter</artifactId>
-	<version>2.2</version>
+	<version>2.3</version>
 	<name>api-service-supportcenter</name>
 	<properties>
 		<!-- Service properties -->

--- a/src/integration-test/resources/CreateAsset/__files/test001_createAsset/mappings/pob_put_configurationitem.json
+++ b/src/integration-test/resources/CreateAsset/__files/test001_createAsset/mappings/pob_put_configurationitem.json
@@ -19,7 +19,9 @@
 						"Virtual.CIKommun": "Sundsvall",
 						"DeliveryDate": "2022-01-01",
 						"EndWarrantyDate": "2022-01-01",
-						"Virtual.LeaseStatus": "ACTIVE"
+						"Virtual.LeaseStatus": "ACTIVE",
+						"Virtual.TjanstStart": "2022-01-01",
+						"Virtual.TjanstSlut": "2025-01-01"
 					},
 					"Memo": {}
 				}

--- a/src/integration-test/resources/CreateAsset/__files/test001_createAsset/request.json
+++ b/src/integration-test/resources/CreateAsset/__files/test001_createAsset/request.json
@@ -7,5 +7,7 @@
 	"warrantyEndDate": "2022-01-01",
 	"deliveryDate": "2022-01-01",
 	"manufacturer": "x_dell",
-	"leaseStatus": "ACTIVE"
+	"leaseStatus": "ACTIVE",
+	"leaseStart": "2022-01-01",
+	"leaseEnd": "2025-01-01"
 }

--- a/src/integration-test/resources/ReadAsset/__files/test001_readAsset/mappings/pob_read_configurationitems.json
+++ b/src/integration-test/resources/ReadAsset/__files/test001_readAsset/mappings/pob_read_configurationitems.json
@@ -122,7 +122,9 @@
 					"LastChangeDate": "",
 					"MonitorStatus": "0",
 					"Virtual.DataloadSyncInfo": "",
-					"Virtual.LeaseStatus": "ACTIVE"
+					"Virtual.LeaseStatus": "ACTIVE",
+					"Virtual.TjanstStart": "2022-01-01 00:00:00",
+					"Virtual.TjanstSlut": "2025-01-01 00:00:00"
 				},
 				"Memo": {}
 			}

--- a/src/integration-test/resources/ReadAsset/__files/test001_readAsset/response.json
+++ b/src/integration-test/resources/ReadAsset/__files/test001_readAsset/response.json
@@ -13,6 +13,8 @@
 		"supplierStatus": "2",
 		"id": "15857",
 		"deliveryDate": "2022-01-01",
-		"leaseStatus": "ACTIVE"
+		"leaseStatus": "ACTIVE",
+		"leaseStart": "2022-01-01",
+		"leaseEnd": "2025-01-01"
 	}
 ]

--- a/src/integration-test/resources/UpdateAsset/__files/test001_updateAsset/mappings/pob_update_asset.json
+++ b/src/integration-test/resources/UpdateAsset/__files/test001_updateAsset/mappings/pob_update_asset.json
@@ -20,7 +20,9 @@
 						"Id": "867403",
 						"DeliveryDate": "2022-02-20",
 						"EndWarrantyDate": "2024-02-20",
-						"Virtual.LeaseStatus": "ACTIVE"
+						"Virtual.LeaseStatus": "ACTIVE",
+						"Virtual.TjanstStart": "2022-02-20",
+						"Virtual.TjanstSlut": "2025-02-20"
 					},
 					"Memo": {
 						"CILeverantorensAnteckningar": {

--- a/src/integration-test/resources/UpdateAsset/__files/test001_updateAsset/request.json
+++ b/src/integration-test/resources/UpdateAsset/__files/test001_updateAsset/request.json
@@ -10,5 +10,7 @@
 	"hardwareStatus": "2",
 	"warrantyEndDate": "2024-02-20",
 	"deliveryDate": "2022-02-20",
-	"leaseStatus": "ACTIVE"
+	"leaseStatus": "ACTIVE",
+	"leaseStart": "2022-02-20",
+	"leaseEnd": "2025-02-20"
 }

--- a/src/integration-test/resources/openapi.yml
+++ b/src/integration-test/resources/openapi.yml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT License
     url: https://opensource.org/licenses/MIT
-  version: "2.2"
+  version: "2.3"
 servers:
 - url: http://localhost:56226
   description: Generated server url
@@ -897,6 +897,18 @@ components:
           description: Lease status
           examples:
           - status1
+        leaseStart:
+          type: string
+          format: date
+          description: Lease start date
+          examples:
+          - 2022-01-01
+        leaseEnd:
+          type: string
+          format: date
+          description: Lease end date
+          examples:
+          - 2022-01-01
       required:
       - modelName
       - serialNumber
@@ -1001,6 +1013,18 @@ components:
           description: Lease status
           examples:
           - status1
+        leaseStart:
+          type: string
+          format: date
+          description: Lease start date
+          examples:
+          - 2022-01-01
+        leaseEnd:
+          type: string
+          format: date
+          description: Lease end date
+          examples:
+          - 2022-01-01
     Case:
       type: object
       description: Case model
@@ -1214,4 +1238,16 @@ components:
           description: Lease status
           examples:
           - status1
+        leaseStart:
+          type: string
+          format: date
+          description: Lease start date
+          examples:
+          - 2022-01-01
+        leaseEnd:
+          type: string
+          format: date
+          description: Lease end date
+          examples:
+          - 2022-01-01
   securitySchemes: {}

--- a/src/main/java/se/sundsvall/supportcenter/api/model/Asset.java
+++ b/src/main/java/se/sundsvall/supportcenter/api/model/Asset.java
@@ -51,6 +51,12 @@ public class Asset {
 	@Schema(examples = "status1", description = "Lease status")
 	private String leaseStatus;
 
+	@Schema(examples = "2022-01-01", description = "Lease start date")
+	private LocalDate leaseStart;
+
+	@Schema(examples = "2022-01-01", description = "Lease end date")
+	private LocalDate leaseEnd;
+
 	public static Asset create() {
 		return new Asset();
 	}
@@ -237,6 +243,32 @@ public class Asset {
 		return this;
 	}
 
+	public LocalDate getLeaseStart() {
+		return leaseStart;
+	}
+
+	public void setLeaseStart(LocalDate leaseStart) {
+		this.leaseStart = leaseStart;
+	}
+
+	public Asset withLeaseStart(LocalDate leaseStart) {
+		this.leaseStart = leaseStart;
+		return this;
+	}
+
+	public LocalDate getLeaseEnd() {
+		return leaseEnd;
+	}
+
+	public void setLeaseEnd(LocalDate leaseEnd) {
+		this.leaseEnd = leaseEnd;
+	}
+
+	public Asset withLeaseEnd(LocalDate leaseEnd) {
+		this.leaseEnd = leaseEnd;
+		return this;
+	}
+
 	@Override
 	public String toString() {
 		return "Asset{" +
@@ -254,6 +286,8 @@ public class Asset {
 			", deliveryDate=" + deliveryDate +
 			", municipalityId='" + municipalityId + '\'' +
 			", leaseStatus='" + leaseStatus + '\'' +
+			", leaseStart=" + leaseStart +
+			", leaseEnd=" + leaseEnd +
 			'}';
 	}
 
@@ -265,11 +299,13 @@ public class Asset {
 		return Objects.equals(id, asset.id) && Objects.equals(serialNumber, asset.serialNumber) && Objects.equals(hardwareName, asset.hardwareName) && Objects.equals(hardwareDescription, asset.hardwareDescription)
 			&& Objects.equals(macAddress, asset.macAddress) && Objects.equals(supplierStatus, asset.supplierStatus) && Objects.equals(hardwareStatus, asset.hardwareStatus) && Objects.equals(manufacturer,
 				asset.manufacturer) && Objects.equals(modelName, asset.modelName) && Objects.equals(modelDescription, asset.modelDescription) && Objects.equals(warrantyEndDate, asset.warrantyEndDate) && Objects.equals(
-					deliveryDate, asset.deliveryDate) && Objects.equals(municipalityId, asset.municipalityId) && Objects.equals(leaseStatus, asset.leaseStatus);
+					deliveryDate, asset.deliveryDate) && Objects.equals(municipalityId, asset.municipalityId) && Objects.equals(leaseStatus, asset.leaseStatus) && Objects.equals(leaseStart, asset.leaseStart) && Objects.equals(
+						leaseEnd, asset.leaseEnd);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(id, serialNumber, hardwareName, hardwareDescription, macAddress, supplierStatus, hardwareStatus, manufacturer, modelName, modelDescription, warrantyEndDate, deliveryDate, municipalityId, leaseStatus);
+		return Objects.hash(id, serialNumber, hardwareName, hardwareDescription, macAddress, supplierStatus, hardwareStatus, manufacturer, modelName, modelDescription, warrantyEndDate, deliveryDate, municipalityId, leaseStatus,
+			leaseStart, leaseEnd);
 	}
 }

--- a/src/main/java/se/sundsvall/supportcenter/api/model/CreateAssetRequest.java
+++ b/src/main/java/se/sundsvall/supportcenter/api/model/CreateAssetRequest.java
@@ -48,6 +48,12 @@ public class CreateAssetRequest {
 	@Schema(examples = "status1", description = "Lease status", requiredMode = NOT_REQUIRED)
 	private String leaseStatus;
 
+	@Schema(examples = "2022-01-01", description = "Lease start date", requiredMode = NOT_REQUIRED)
+	private LocalDate leaseStart;
+
+	@Schema(examples = "2022-01-01", description = "Lease end date", requiredMode = NOT_REQUIRED)
+	private LocalDate leaseEnd;
+
 	public static CreateAssetRequest create() {
 		return new CreateAssetRequest();
 	}
@@ -195,6 +201,32 @@ public class CreateAssetRequest {
 		return this;
 	}
 
+	public LocalDate getLeaseStart() {
+		return leaseStart;
+	}
+
+	public void setLeaseStart(LocalDate leaseStart) {
+		this.leaseStart = leaseStart;
+	}
+
+	public CreateAssetRequest withLeaseStart(LocalDate leaseStart) {
+		this.leaseStart = leaseStart;
+		return this;
+	}
+
+	public LocalDate getLeaseEnd() {
+		return leaseEnd;
+	}
+
+	public void setLeaseEnd(LocalDate leaseEnd) {
+		this.leaseEnd = leaseEnd;
+	}
+
+	public CreateAssetRequest withLeaseEnd(LocalDate leaseEnd) {
+		this.leaseEnd = leaseEnd;
+		return this;
+	}
+
 	@Override
 	public String toString() {
 		return "CreateAssetRequest{" +
@@ -209,6 +241,8 @@ public class CreateAssetRequest {
 			", deliveryDate=" + deliveryDate +
 			", municipalityId='" + municipalityId + '\'' +
 			", leaseStatus='" + leaseStatus + '\'' +
+			", leaseStart=" + leaseStart +
+			", leaseEnd=" + leaseEnd +
 			'}';
 	}
 
@@ -219,11 +253,12 @@ public class CreateAssetRequest {
 		CreateAssetRequest that = (CreateAssetRequest) o;
 		return Objects.equals(manufacturer, that.manufacturer) && Objects.equals(modelName, that.modelName) && Objects.equals(modelDescription, that.modelDescription) && Objects.equals(serialNumber, that.serialNumber)
 			&& Objects.equals(macAddress, that.macAddress) && Objects.equals(warrantyEndDate, that.warrantyEndDate) && Objects.equals(supplierStatus, that.supplierStatus) && Objects.equals(hardwareStatus,
-				that.hardwareStatus) && Objects.equals(deliveryDate, that.deliveryDate) && Objects.equals(municipalityId, that.municipalityId) && Objects.equals(leaseStatus, that.leaseStatus);
+				that.hardwareStatus) && Objects.equals(deliveryDate, that.deliveryDate) && Objects.equals(municipalityId, that.municipalityId) && Objects.equals(leaseStatus, that.leaseStatus) && Objects.equals(leaseStart,
+					that.leaseStart) && Objects.equals(leaseEnd, that.leaseEnd);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(manufacturer, modelName, modelDescription, serialNumber, macAddress, warrantyEndDate, supplierStatus, hardwareStatus, deliveryDate, municipalityId, leaseStatus);
+		return Objects.hash(manufacturer, modelName, modelDescription, serialNumber, macAddress, warrantyEndDate, supplierStatus, hardwareStatus, deliveryDate, municipalityId, leaseStatus, leaseStart, leaseEnd);
 	}
 }

--- a/src/main/java/se/sundsvall/supportcenter/api/model/UpdateAssetRequest.java
+++ b/src/main/java/se/sundsvall/supportcenter/api/model/UpdateAssetRequest.java
@@ -39,6 +39,12 @@ public class UpdateAssetRequest {
 	@Schema(examples = "status1", description = "Lease status", requiredMode = NOT_REQUIRED)
 	private String leaseStatus;
 
+	@Schema(examples = "2022-01-01", description = "Lease start date", requiredMode = NOT_REQUIRED)
+	private LocalDate leaseStart;
+
+	@Schema(examples = "2022-01-01", description = "Lease end date", requiredMode = NOT_REQUIRED)
+	private LocalDate leaseEnd;
+
 	public static UpdateAssetRequest create() {
 		return new UpdateAssetRequest();
 	}
@@ -160,6 +166,32 @@ public class UpdateAssetRequest {
 		return this;
 	}
 
+	public LocalDate getLeaseStart() {
+		return leaseStart;
+	}
+
+	public void setLeaseStart(LocalDate leaseStart) {
+		this.leaseStart = leaseStart;
+	}
+
+	public UpdateAssetRequest withLeaseStart(LocalDate leaseStart) {
+		this.leaseStart = leaseStart;
+		return this;
+	}
+
+	public LocalDate getLeaseEnd() {
+		return leaseEnd;
+	}
+
+	public void setLeaseEnd(LocalDate leaseEnd) {
+		this.leaseEnd = leaseEnd;
+	}
+
+	public UpdateAssetRequest withLeaseEnd(LocalDate leaseEnd) {
+		this.leaseEnd = leaseEnd;
+		return this;
+	}
+
 	@Override
 	public String toString() {
 		return "UpdateAssetRequest{" +
@@ -172,6 +204,8 @@ public class UpdateAssetRequest {
 			", deliveryDate=" + deliveryDate +
 			", municipalityId='" + municipalityId + '\'' +
 			", leaseStatus='" + leaseStatus + '\'' +
+			", leaseStart=" + leaseStart +
+			", leaseEnd=" + leaseEnd +
 			'}';
 	}
 
@@ -182,11 +216,11 @@ public class UpdateAssetRequest {
 		UpdateAssetRequest that = (UpdateAssetRequest) o;
 		return Objects.equals(note, that.note) && Objects.equals(hardwareName, that.hardwareName) && Objects.equals(macAddress, that.macAddress) && Objects.equals(supplierStatus, that.supplierStatus)
 			&& Objects.equals(hardwareStatus, that.hardwareStatus) && Objects.equals(warrantyEndDate, that.warrantyEndDate) && Objects.equals(deliveryDate, that.deliveryDate) && Objects.equals(municipalityId,
-				that.municipalityId) && Objects.equals(leaseStatus, that.leaseStatus);
+				that.municipalityId) && Objects.equals(leaseStatus, that.leaseStatus) && Objects.equals(leaseStart, that.leaseStart) && Objects.equals(leaseEnd, that.leaseEnd);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(note, hardwareName, macAddress, supplierStatus, hardwareStatus, warrantyEndDate, deliveryDate, municipalityId, leaseStatus);
+		return Objects.hash(note, hardwareName, macAddress, supplierStatus, hardwareStatus, warrantyEndDate, deliveryDate, municipalityId, leaseStatus, leaseStart, leaseEnd);
 	}
 }

--- a/src/main/java/se/sundsvall/supportcenter/service/mapper/ConfigurationMapper.java
+++ b/src/main/java/se/sundsvall/supportcenter/service/mapper/ConfigurationMapper.java
@@ -19,6 +19,8 @@ import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMa
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_END_WARRANTY_DATE;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_HARDWARE_NAME;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_HARDWARE_STATUS;
+import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_LEASE_END;
+import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_LEASE_START;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_LEASE_STATUS;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_MAC_ADDRESS;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_MUNICIPALITY;
@@ -84,6 +86,8 @@ public final class ConfigurationMapper {
 		ofNullable(updateAssetRequest.getWarrantyEndDate()).ifPresent(value -> dataMap.put(KEY_END_WARRANTY_DATE, value.format(DATE_FORMATTER)));
 		ofNullable(updateAssetRequest.getMunicipalityId()).ifPresent(value -> dataMap.put(KEY_MUNICIPALITY, MUNICIPALITY_MAP.get(value)));
 		ofNullable(updateAssetRequest.getLeaseStatus()).ifPresent(value -> dataMap.put(KEY_LEASE_STATUS, value));
+		ofNullable(updateAssetRequest.getLeaseStart()).ifPresent(value -> dataMap.put(KEY_LEASE_START, value.format(DATE_FORMATTER)));
+		ofNullable(updateAssetRequest.getLeaseEnd()).ifPresent(value -> dataMap.put(KEY_LEASE_END, value.format(DATE_FORMATTER)));
 		return dataMap;
 	}
 }

--- a/src/main/java/se/sundsvall/supportcenter/service/mapper/CreateAssetMapper.java
+++ b/src/main/java/se/sundsvall/supportcenter/service/mapper/CreateAssetMapper.java
@@ -21,6 +21,8 @@ import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMa
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_HARDWARE_STATUS;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_ITEM;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_ITEM_ID_OPTION;
+import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_LEASE_END;
+import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_LEASE_START;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_LEASE_STATUS;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_MAC_ADDRESS;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_MANUFACTURER;
@@ -104,6 +106,8 @@ public final class CreateAssetMapper {
 		Optional.ofNullable(createAssetRequest.getWarrantyEndDate()).ifPresent(value -> dataMap.put(KEY_END_WARRANTY_DATE, value.format(DATE_FORMATTER)));
 		Optional.ofNullable(createAssetRequest.getMunicipalityId()).ifPresent(value -> dataMap.put(KEY_MUNICIPALITY, MUNICIPALITY_MAP.get(value)));
 		Optional.ofNullable(createAssetRequest.getLeaseStatus()).ifPresent(value -> dataMap.put(KEY_LEASE_STATUS, value));
+		Optional.ofNullable(createAssetRequest.getLeaseStart()).ifPresent(value -> dataMap.put(KEY_LEASE_START, value.format(DATE_FORMATTER)));
+		Optional.ofNullable(createAssetRequest.getLeaseEnd()).ifPresent(value -> dataMap.put(KEY_LEASE_END, value.format(DATE_FORMATTER)));
 
 		return dataMap;
 	}

--- a/src/main/java/se/sundsvall/supportcenter/service/mapper/GetAssetMapper.java
+++ b/src/main/java/se/sundsvall/supportcenter/service/mapper/GetAssetMapper.java
@@ -22,6 +22,8 @@ import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMa
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_HARDWARE_STATUS;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_ITEM_ID;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_ITEM_ID_OPTION;
+import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_LEASE_END;
+import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_LEASE_START;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_LEASE_STATUS;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_MAC_ADDRESS;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_MANUFACTURER;
@@ -84,7 +86,9 @@ public final class GetAssetMapper {
 				.withModelDescription((String) ofNullable(itemAttributes).orElse(emptyMap()).get(KEY_DESCRIPTION))
 				.withManufacturer(toManufacturer(convertObjectToMap(ofNullable(itemAttributes).orElse(emptyMap()).get(KEY_MANUFACTURER))))
 				.withMunicipalityId(toMunicipalityId((String) data.get(KEY_MUNICIPALITY)))
-				.withLeaseStatus((String) data.get(KEY_LEASE_STATUS)))
+				.withLeaseStatus((String) data.get(KEY_LEASE_STATUS))
+				.withLeaseStart(toLocalDate((String) data.get(KEY_LEASE_START)))
+				.withLeaseEnd(toLocalDate((String) data.get(KEY_LEASE_END))))
 			.orElse(null);
 	}
 

--- a/src/main/java/se/sundsvall/supportcenter/service/mapper/constant/ConfigurationMapperConstants.java
+++ b/src/main/java/se/sundsvall/supportcenter/service/mapper/constant/ConfigurationMapperConstants.java
@@ -22,6 +22,8 @@ public final class ConfigurationMapperConstants {
 	public static final String KEY_SUPPLIER_STATUS = "Virtual.LeverantorensStatus";
 	public static final String KEY_MUNICIPALITY = "Virtual.CIKommun";
 	public static final String KEY_LEASE_STATUS = "Virtual.LeaseStatus";
+	public static final String KEY_LEASE_START = "Virtual.TjanstStart";
+	public static final String KEY_LEASE_END = "Virtual.TjanstSlut";
 	public static final String TYPE_CLOSURE_CODE = "ClosureCode";
 	public static final String TYPE_CASE_CATEGORY = "CaseCategory";
 	public static final String TYPE_CONFIGURATION_ITEM = "ConfigurationItem";

--- a/src/test/java/se/sundsvall/supportcenter/api/model/AssetTest.java
+++ b/src/test/java/se/sundsvall/supportcenter/api/model/AssetTest.java
@@ -49,6 +49,8 @@ class AssetTest {
 		final var warrantyEndDate = LocalDate.now().plusDays(365);
 		final var municipalityId = "municipalityId";
 		final var leaseStatus = "leaseStatus";
+		final var leaseStart = LocalDate.now().plusDays(7);
+		final var leaseEnd = LocalDate.now().plusDays(500);
 
 		final var asset = Asset.create()
 			.withId(id)
@@ -64,7 +66,9 @@ class AssetTest {
 			.withDeliveryDate(deliveryDate)
 			.withWarrantyEndDate(warrantyEndDate)
 			.withMunicipalityId(municipalityId)
-			.withLeaseStatus(leaseStatus);
+			.withLeaseStatus(leaseStatus)
+			.withLeaseStart(leaseStart)
+			.withLeaseEnd(leaseEnd);
 
 		assertThat(asset).isNotNull().hasNoNullFieldsOrProperties();
 		assertThat(asset.getId()).isEqualTo(id);
@@ -81,6 +85,8 @@ class AssetTest {
 		assertThat(asset.getWarrantyEndDate()).isEqualTo(warrantyEndDate);
 		assertThat(asset.getMunicipalityId()).isEqualTo(municipalityId);
 		assertThat(asset.getLeaseStatus()).isEqualTo(leaseStatus);
+		assertThat(asset.getLeaseStart()).isEqualTo(leaseStart);
+		assertThat(asset.getLeaseEnd()).isEqualTo(leaseEnd);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/supportcenter/api/model/CreateAssetRequestTest.java
+++ b/src/test/java/se/sundsvall/supportcenter/api/model/CreateAssetRequestTest.java
@@ -46,6 +46,8 @@ class CreateAssetRequestTest {
 		final var deliveryDate = LocalDate.now().plusDays(5L);
 		final var municipalityId = "municipalityId";
 		final var leaseStatus = "leaseStatus";
+		final var leaseStart = LocalDate.now().plusDays(5L);
+		final var leaseEnd = LocalDate.now().plusDays(400L);
 
 		final var createAssetRequest = CreateAssetRequest.create()
 			.withManufacturer(manufacturer)
@@ -58,7 +60,9 @@ class CreateAssetRequestTest {
 			.withHardwareStatus(hardwareStatus)
 			.withDeliveryDate(deliveryDate)
 			.withMunicipalityId(municipalityId)
-			.withLeaseStatus(leaseStatus);
+			.withLeaseStatus(leaseStatus)
+			.withLeaseStart(leaseStart)
+			.withLeaseEnd(leaseEnd);
 
 		assertThat(createAssetRequest).hasNoNullFieldsOrProperties();
 		assertThat(createAssetRequest.getManufacturer()).isEqualTo(manufacturer);
@@ -72,6 +76,8 @@ class CreateAssetRequestTest {
 		assertThat(createAssetRequest.getDeliveryDate()).isEqualTo(deliveryDate);
 		assertThat(createAssetRequest.getMunicipalityId()).isEqualTo(municipalityId);
 		assertThat(createAssetRequest.getLeaseStatus()).isEqualTo(leaseStatus);
+		assertThat(createAssetRequest.getLeaseStart()).isEqualTo(leaseStart);
+		assertThat(createAssetRequest.getLeaseEnd()).isEqualTo(leaseEnd);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/supportcenter/api/model/UpdateAssetRequestTest.java
+++ b/src/test/java/se/sundsvall/supportcenter/api/model/UpdateAssetRequestTest.java
@@ -44,6 +44,8 @@ class UpdateAssetRequestTest {
 		final var warrantyEndDate = LocalDate.now().plusDays(700);
 		final var municipalityId = "municipalityId";
 		final var leaseStatus = "leaseStatus";
+		final var leaseStart = LocalDate.now().plusDays(2);
+		final var leaseEnd = LocalDate.now().plusDays(800);
 
 		final var updateCaseRequest = UpdateAssetRequest.create()
 			.withNote(note)
@@ -54,7 +56,9 @@ class UpdateAssetRequestTest {
 			.withDeliveryDate(deliveryDate)
 			.withWarrantyEndDate(warrantyEndDate)
 			.withMunicipalityId(municipalityId)
-			.withLeaseStatus(leaseStatus);
+			.withLeaseStatus(leaseStatus)
+			.withLeaseStart(leaseStart)
+			.withLeaseEnd(leaseEnd);
 
 		assertThat(updateCaseRequest).isNotNull().hasNoNullFieldsOrProperties();
 		assertThat(updateCaseRequest.getNote()).isEqualTo(note);
@@ -66,6 +70,8 @@ class UpdateAssetRequestTest {
 		assertThat(updateCaseRequest.getWarrantyEndDate()).isEqualTo(warrantyEndDate);
 		assertThat(updateCaseRequest.getMunicipalityId()).isEqualTo(municipalityId);
 		assertThat(updateCaseRequest.getLeaseStatus()).isEqualTo(leaseStatus);
+		assertThat(updateCaseRequest.getLeaseStart()).isEqualTo(leaseStart);
+		assertThat(updateCaseRequest.getLeaseEnd()).isEqualTo(leaseEnd);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/supportcenter/service/mapper/ConfigurationMapperTest.java
+++ b/src/test/java/se/sundsvall/supportcenter/service/mapper/ConfigurationMapperTest.java
@@ -104,6 +104,8 @@ class ConfigurationMapperTest {
 		final var note = Note.create().withType(NoteType.SUPPLIERNOTE).withText("text");
 		final var deliveryDate = LocalDate.now().plusDays(1);
 		final var warrantyEndDate = LocalDate.now().plusDays(700);
+		final var leaseStart = LocalDate.now().plusDays(2);
+		final var leaseEnd = LocalDate.now().plusDays(800);
 
 		// Parameter values
 		final var updateAssetRequest = UpdateAssetRequest.create()
@@ -113,7 +115,9 @@ class ConfigurationMapperTest {
 			.withSupplierStatus("supplierStatus")
 			.withDeliveryDate(deliveryDate)
 			.withWarrantyEndDate(warrantyEndDate)
-			.withLeaseStatus("status1");
+			.withLeaseStatus("status1")
+			.withLeaseStart(leaseStart)
+			.withLeaseEnd(leaseEnd);
 
 		final var assetId = "assetId";
 
@@ -129,6 +133,8 @@ class ConfigurationMapperTest {
 		assertThat(result.getData()).containsEntry("DeliveryDate", deliveryDate.format(DATE_FORMATTER));
 		assertThat(result.getData()).containsEntry("EndWarrantyDate", warrantyEndDate.format(DATE_FORMATTER));
 		assertThat(result.getData()).containsEntry("Virtual.LeaseStatus", "status1");
+		assertThat(result.getData()).containsEntry("Virtual.TjanstStart", leaseStart.format(DATE_FORMATTER));
+		assertThat(result.getData()).containsEntry("Virtual.TjanstSlut", leaseEnd.format(DATE_FORMATTER));
 		assertThat(result.getMemo()).extractingByKey("CILeverantorensAnteckningar").extracting(
 			PobMemo::getExtension,
 			PobMemo::getHandleSeparators,

--- a/src/test/java/se/sundsvall/supportcenter/service/mapper/CreateAssetMapperTest.java
+++ b/src/test/java/se/sundsvall/supportcenter/service/mapper/CreateAssetMapperTest.java
@@ -17,6 +17,8 @@ import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMa
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_HARDWARE_STATUS;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_ITEM;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_ITEM_ID_OPTION;
+import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_LEASE_END;
+import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_LEASE_START;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_LEASE_STATUS;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_MAC_ADDRESS;
 import static se.sundsvall.supportcenter.service.mapper.constant.ConfigurationMapperConstants.KEY_MANUFACTURER;
@@ -68,6 +70,8 @@ class CreateAssetMapperTest {
 		final var hardwareStatus = "hardwareStatus";
 		final var municipalityId = "2281";
 		final var leaseStatus = "leaseStatus";
+		final var leaseStart = LocalDate.now().plusDays(5);
+		final var leaseEnd = LocalDate.now().plusDays(400);
 
 		final var createAssetRequest = CreateAssetRequest.create()
 			.withManufacturer(manufacturer)
@@ -79,7 +83,9 @@ class CreateAssetMapperTest {
 			.withDeliveryDate(LocalDate.now().plusDays(2))
 			.withWarrantyEndDate(LocalDate.now().plusDays(360))
 			.withMunicipalityId(municipalityId)
-			.withLeaseStatus(leaseStatus);
+			.withLeaseStatus(leaseStatus)
+			.withLeaseStart(leaseStart)
+			.withLeaseEnd(leaseEnd);
 
 		// Call
 		final var result = CreateAssetMapper.toPobPayloadForCreatingConfigurationItem(itemId, createAssetRequest);
@@ -95,6 +101,8 @@ class CreateAssetMapperTest {
 		assertThat(result.getData()).containsEntry(KEY_END_WARRANTY_DATE, createAssetRequest.getWarrantyEndDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
 		assertThat(result.getData()).containsEntry(KEY_MUNICIPALITY, "Sundsvall");
 		assertThat(result.getData()).containsEntry(KEY_LEASE_STATUS, leaseStatus);
+		assertThat(result.getData()).containsEntry(KEY_LEASE_START, leaseStart.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+		assertThat(result.getData()).containsEntry(KEY_LEASE_END, leaseEnd.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/supportcenter/service/mapper/GetAssetMapperTest.java
+++ b/src/test/java/se/sundsvall/supportcenter/service/mapper/GetAssetMapperTest.java
@@ -104,6 +104,8 @@ class GetAssetMapperTest {
 		final var municipality1 = "Sundsvall";
 		final var municipalityId1 = "2281";
 		final var leaseStatus1 = "leaseStatus-1";
+		final var leaseStart1 = "2023-02-01 00:00:00";
+		final var leaseEnd1 = "2025-02-01 00:00:00";
 		final var configurationItemId2 = "222";
 		final var hardwareName2 = "hardwareName-2";
 		final var hardwareDescription2 = "hardwareDescription-2";
@@ -116,6 +118,8 @@ class GetAssetMapperTest {
 		final var municipality2 = "Ånge";
 		final var municipalityId2 = "2260";
 		final var leaseStatus2 = "leaseStatus-2";
+		final var leaseStart2 = "2024-02-01 00:00:00";
+		final var leaseEnd2 = "2026-02-01 00:00:00";
 
 		final var manufacturer = "manufacturer";
 
@@ -138,6 +142,8 @@ class GetAssetMapperTest {
 		dataMap1.put("EndWarrantyDate", warrantyEndDate1);
 		dataMap1.put("Virtual.CIKommun", municipality1);
 		dataMap1.put("Virtual.LeaseStatus", leaseStatus1);
+		dataMap1.put("Virtual.TjanstStart", leaseStart1);
+		dataMap1.put("Virtual.TjanstSlut", leaseEnd1);
 
 		var dataMap2 = new HashMap<String, Object>();
 		dataMap2.put("Id", configurationItemId2);
@@ -151,6 +157,8 @@ class GetAssetMapperTest {
 		dataMap2.put("EndWarrantyDate", warrantyEndDate2);
 		dataMap2.put("Virtual.CIKommun", municipality2);
 		dataMap2.put("Virtual.LeaseStatus", leaseStatus2);
+		dataMap2.put("Virtual.TjanstStart", leaseStart2);
+		dataMap2.put("Virtual.TjanstSlut", leaseEnd2);
 
 		final var configurationItems = List.of(
 			new PobPayload()
@@ -186,7 +194,9 @@ class GetAssetMapperTest {
 				Asset::getModelDescription,
 				Asset::getModelName,
 				Asset::getMunicipalityId,
-				Asset::getLeaseStatus)
+				Asset::getLeaseStatus,
+				Asset::getLeaseStart,
+				Asset::getLeaseEnd)
 			.containsExactly(
 				tuple(
 					configurationItemId1,
@@ -202,7 +212,9 @@ class GetAssetMapperTest {
 					modelDescription,
 					modelName,
 					municipalityId1,
-					leaseStatus1),
+					leaseStatus1,
+					LocalDate.parse(leaseStart1, DATE_TIME_FORMATTER),
+					LocalDate.parse(leaseEnd1, DATE_TIME_FORMATTER)),
 				tuple(
 					configurationItemId2,
 					hardwareDescription2,
@@ -217,7 +229,9 @@ class GetAssetMapperTest {
 					modelDescription,
 					modelName,
 					municipalityId2,
-					leaseStatus2));
+					leaseStatus2,
+					LocalDate.parse(leaseStart2, DATE_TIME_FORMATTER),
+					LocalDate.parse(leaseEnd2, DATE_TIME_FORMATTER)));
 	}
 
 	@Test
@@ -235,6 +249,8 @@ class GetAssetMapperTest {
 		final var municipality = "Sundsvall";
 		final var municipalityId = "2281";
 		final var leaseStatus = "leaseStatus";
+		final var leaseStart = "2023-02-01 00:00:00";
+		final var leaseEnd = "2025-02-01 00:00:00";
 
 		final var dataMap = new HashMap<String, Object>();
 		dataMap.put("Id", configurationItemId);
@@ -248,6 +264,8 @@ class GetAssetMapperTest {
 		dataMap.put("EndWarrantyDate", warrantyEndDate);
 		dataMap.put("Virtual.CIKommun", municipality);
 		dataMap.put("Virtual.LeaseStatus", leaseStatus);
+		dataMap.put("Virtual.TjanstStart", leaseStart);
+		dataMap.put("Virtual.TjanstSlut", leaseEnd);
 
 		final var configurationItems = List.of(
 			new PobPayload()
@@ -275,7 +293,9 @@ class GetAssetMapperTest {
 				Asset::getManufacturer,
 				Asset::getModelName,
 				Asset::getMunicipalityId,
-				Asset::getLeaseStatus)
+				Asset::getLeaseStatus,
+				Asset::getLeaseStart,
+				Asset::getLeaseEnd)
 			.containsExactly(tuple(
 				configurationItemId,
 				hardwareDescription,
@@ -289,6 +309,8 @@ class GetAssetMapperTest {
 				null,
 				null,
 				municipalityId,
-				leaseStatus));
+				leaseStatus,
+				LocalDate.parse(leaseStart, DATE_TIME_FORMATTER),
+				LocalDate.parse(leaseEnd, DATE_TIME_FORMATTER)));
 	}
 }


### PR DESCRIPTION
Map leaseStart to POB Virtual.TjanstStart and leaseEnd to Virtual.TjanstSlut. Both are LocalDate, written as yyyy-MM-dd and read from POB's yyyy-MM-dd HH:mm:ss format, following the existing deliveryDate/warrantyEndDate pattern.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
